### PR TITLE
Match error disorder

### DIFF
--- a/arpeggio/core/protein_reader.py
+++ b/arpeggio/core/protein_reader.py
@@ -16,7 +16,11 @@ import openbabel as ob
 
 
 def _get_res_id(atom_sites, i):
-    return atom_sites["pdbe_label_seq_id"][i] if "pdbe_label_seq_id" in atom_sites else atom_sites["auth_seq_id"][i]
+    return int(
+        atom_sites["pdbe_label_seq_id"][i]
+        if "pdbe_label_seq_id" in atom_sites
+        else atom_sites["auth_seq_id"][i]
+    )
 
 
 def _get_b_factor(atom_sites, i):

--- a/arpeggio/core/protein_reader.py
+++ b/arpeggio/core/protein_reader.py
@@ -16,11 +16,7 @@ import openbabel as ob
 
 
 def _get_res_id(atom_sites, i):
-    return int(
-        atom_sites["pdbe_label_seq_id"][i]
-        if "pdbe_label_seq_id" in atom_sites
-        else atom_sites["auth_seq_id"][i]
-    )
+    return atom_sites["pdbe_label_seq_id"][i] if "pdbe_label_seq_id" in atom_sites else atom_sites["auth_seq_id"][i]
 
 
 def _get_b_factor(atom_sites, i):
@@ -352,7 +348,7 @@ def _init_biopython_atom(builder, atom_sites, i):
             _get_b_factor(atom_sites, i),
             float(atom_sites["occupancy"][i]),
             " "
-            if atom_sites["label_alt_id"][i] == "."
+            if atom_sites["label_alt_id"][i] in {".", "?"}
             else atom_sites["label_alt_id"][i],
             atom_sites["label_atom_id"][i],
             int(atom_sites["id"][i]),
@@ -371,7 +367,7 @@ def _init_biopython_atom(builder, atom_sites, i):
             _get_b_factor(atom_sites, i),
             float(atom_sites["occupancy"][i]),
             " "
-            if atom_sites["label_alt_id"][i] == "."
+            if atom_sites["label_alt_id"][i] in {".", "?"}
             else atom_sites["label_alt_id"][i],
             atom_sites["label_atom_id"][i],
             int(atom_sites["id"][i]),


### PR DESCRIPTION
This fixes the error that has a message like this:
```
ERROR//13:26:29.697//OpenBabel OBAtom with serial number 8859 could not be matched to a BioPython counterpart.
Traceback (most recent call last):
  File "/home/migwell/miniconda3/envs/arpeggio/lib/python3.7/site-packages/arpeggio/core/interactions.py", line 1996, in _establish_structure_mappping
    biopython_atom = serial_to_bio[serial]
KeyError: 8859
```

This happens because the `protein_reader` module treats `?` in the `label_alt_id` as though the atom has an alternate atom, and therefore is disordered, which ultimately messes up the ID mapping. However I believe that it's much better to treat `?` as though it is *not* disordered, and indeed if I do this, it fixes run errors that I encounter. Notably this is *not* a duplicate of #4, which has the same exception class, but is related to the fact that PDB input is broken. This error happens with .mmcif files instead.