### PR TITLE
Allow missing chem_comp.name (fixes PDBeurope/arpeggio#28)

### DIFF
--- a/arpeggio/core/protein_reader.py
+++ b/arpeggio/core/protein_reader.py
@@ -428,7 +428,7 @@ def get_component_types(path):
                 if not comp_type == config.ComponentType(5).name:
                     component_types[chem_comp['id'][i]] = comp_type
                 else:
-                    if chem_comp['name'][i].upper() == 'WATER':
+                    if chem_comp['id'][i].upper() == 'HOH' or chem_comp['id'][i].upper() == 'DOD':
                         component_types[chem_comp['id'][i]] = config.ComponentType(8).name
                     else:
                         component_types[chem_comp['id'][i]] = config.ComponentType(7).name


### PR DESCRIPTION
This PR fixes bug #28 as suggested there, by looking for HOH in comp_name.id instead.

In addition, water is often present as DOD and would previously not have been recognized as water. It is now handled as HOH.